### PR TITLE
Example of extern type crash in PR 1539

### DIFF
--- a/tests/ffi/lib.rs
+++ b/tests/ffi/lib.rs
@@ -373,7 +373,14 @@ pub mod ffi {
     extern "Rust" {
         type CrossModuleRustType = crate::module::CrossModuleRustType;
         fn r_get_value_from_cross_module_rust_type(value: &CrossModuleRustType) -> i32;
+
+        type Any = crate::module::CrossModuleRustType;
+        fn repro(bad: &mut CrossModuleRustType) -> &mut Any;
     }
+}
+
+fn repro(bad: &mut ffi::CrossModuleRustType) -> &mut ffi::Any {
+    bad
 }
 
 mod other {

--- a/tests/ffi/tests.cc
+++ b/tests/ffi/tests.cc
@@ -994,6 +994,7 @@ extern "C" const char *cxx_run_test() noexcept {
 
   ASSERT(123 == r_get_value_from_cross_module_rust_type(
       *r_boxed_cross_module_rust_type(123)));
+  repro(*r_boxed_cross_module_rust_type(123)).fill('?');
 
   cxx_test_suite_set_correct();
   return nullptr;

--- a/tests/ffi/tests.h
+++ b/tests/ffi/tests.h
@@ -249,3 +249,7 @@ public:
 
 std::unique_ptr<I> ns_c_return_unique_ptr_ns();
 } // namespace I
+
+namespace tests {
+using Any = std::array<char, 1000>;
+}


### PR DESCRIPTION
```console
dtolnay:cxx$ cargo test --test=test test_c_call_r
    Finished `test` profile [unoptimized + debuginfo] target(s) in 0.03s
     Running tests/test.rs (target/debug/deps/test-fc5568902e6e5e36)

running 1 test
malloc(): corrupted top size
error: test failed, to rerun pass `--test test`

Caused by:
  process didn't exit successfully: `target/debug/deps/test-fc5568902e6e5e36 test_c_call_r` (signal: 6, SIGABRT: process abort signal)
```